### PR TITLE
Improve the phrasing of the listener count in lastfm

### DIFF
--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -72,7 +72,7 @@ class LastFM(object):
             currently_listening = current_track.get_listener_count() - 1
             if currently_listening:
                 track_info += ', and so {0} {1} other {2}.'.format(
-                    'is' if currently_listening is 1 else 'are', currently_listening,
+                    'has' if currently_listening is 1 else 'have', currently_listening,
                     'user' if currently_listening is 1 else 'users')
 
         except (pylast.NetworkError, pylast.MalformedResponseError, pylast.WSError) as err:


### PR DESCRIPTION
After taking some time to compare statistics reflected on last.fm, I'm convinced that the "listener" count actually displays the count of people who _have_ listened to said track/artist, as opposed to those who are _currently_ listening to said track/artist, though there is no formal definition of "listener" in the context of last.fm anywhere.

As such, a trivial change from the present tense 'is' and 'are' to 'has' and 'have' is all that I believe must be done.